### PR TITLE
[feat] 카드 생성 멀티스텝 폼 1차 구현

### DIFF
--- a/@types/webview.d.ts
+++ b/@types/webview.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: ReactNativeWebView;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Took-FE",
+  "name": "took-fe",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.5.2",
@@ -33,7 +33,9 @@
     "sonner": "^2.0.1",
     "swiper": "^11.2.4",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "ts-pattern": "^5.6.2",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.50.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-progress": "^1.1.2",
@@ -28,8 +29,9 @@
     "next-themes": "^0.4.4",
     "react": "^18",
     "react-dom": "^18",
-    "swiper": "^11.2.4",
+    "react-hook-form": "^7.54.2",
     "sonner": "^2.0.1",
+    "swiper": "^11.2.4",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^4.1.3
+        version: 4.1.3(react-hook-form@7.54.2(react@18.3.1))
       '@radix-ui/react-avatar':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -50,6 +53,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.54.2
+        version: 7.54.2(react@18.3.1)
       sonner:
         specifier: ^2.0.1
         version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -444,6 +450,11 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@hookform/resolvers@4.1.3':
+    resolution: {integrity: sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -674,6 +685,9 @@ packages:
 
   '@rushstack/eslint-patch@1.10.5':
     resolution: {integrity: sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2400,6 +2414,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.54.2:
+    resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -3201,6 +3221,11 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@hookform/resolvers@4.1.3(react-hook-form@7.54.2(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.54.2(react@18.3.1)
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -3378,6 +3403,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.10.5': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -5387,6 +5414,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.54.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,12 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
+      ts-pattern:
+        specifier: ^5.6.2
+        version: 5.6.2
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
     devDependencies:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.50.1
@@ -2740,6 +2746,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-pattern@5.6.2:
+    resolution: {integrity: sha512-d4IxJUXROL5NCa3amvMg6VQW2HVtZYmUTPfvVtO7zJWGYLJ+mry9v2OmYm+z67aniQoQ8/yFNadiEwtNS9qQiw==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -2871,6 +2880,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
 
@@ -5806,6 +5818,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-pattern@5.6.2: {}
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -5964,3 +5978,5 @@ snapshots:
   yaml@2.7.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.2: {}

--- a/src/features/multi-step-form/config/index.ts
+++ b/src/features/multi-step-form/config/index.ts
@@ -10,5 +10,9 @@ export const CAREER_FORM = {
   },
 };
 
-// 백엔드
+// 백엔드 - 논의 : 이미지 파일 제한크기
 export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+// 스텝 상수
+export const TOTAL_STEPS = 4;
+export const MINIMUM_STEP = 1;

--- a/src/features/multi-step-form/schema/index.ts
+++ b/src/features/multi-step-form/schema/index.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const cardCreateSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .refine((value) => value.length > 1, {
+      message: '이름은 2글자 이상이어야 합니다.',
+    }),
+  detail_career: z
+    .string()
+    .min(1)
+    .max(100)
+    .refine((value) => value.length > 1, {
+      message: '세부직군은 2글자 이상이어야 합니다.',
+    }),
+  domain: z
+    .string()
+    .min(1)
+    .max(100)
+    .refine((value) => value.length > 1, { message: '도메인은 2글자 이상이어야 합니다.' }),
+  description: z
+    .string()
+    .min(1)
+    .max(40)
+    .refine((value) => value.length > 1 && value.length < 40, {
+      message: '한 줄 소개는 2글자 이상 40글자 이하로 작성해주세요.',
+    }),
+});
+
+export type CareerFormData = z.infer<typeof cardCreateSchema>;

--- a/src/features/multi-step-form/ui/careerForm/errorMsg.tsx
+++ b/src/features/multi-step-form/ui/careerForm/errorMsg.tsx
@@ -1,0 +1,11 @@
+function ErrorMsg({ errorMsg }: { errorMsg: string | undefined }) {
+  if (!errorMsg) {
+    return null;
+  }
+
+  return (
+    <div className='text-error-medium text-sm font-bold'>{errorMsg}</div>
+  )
+}
+
+export default ErrorMsg;

--- a/src/features/multi-step-form/ui/careerForm/firstStep.tsx
+++ b/src/features/multi-step-form/ui/careerForm/firstStep.tsx
@@ -1,11 +1,22 @@
+import { Controller, useFormContext } from 'react-hook-form';
+
 import { cn } from '@/shared/lib/utils';
 import { spacingStyles } from '@/shared/spacing';
 import WrappedInput from '@/shared/ui/Input';
+import WrappedTagInput from '@/shared/ui/Input/tagInput';
 
 import AvatarImg from '../../components/AvartarImg';
 import { CAREER_FORM } from '../../config';
+import { CareerFormData } from '../../schema';
+
+import ErrorMsg from './errorMsg';
 
 function FirstStep() {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<CareerFormData>();
+
   return (
     <>
       <header className='flex flex-col gap-3'>
@@ -17,10 +28,47 @@ function FirstStep() {
           <div className='flex justify-center'>
             <AvatarImg />
           </div>
-          <WrappedInput title='이름' placeholder='이름을 입력해주세요.' />
-          <WrappedInput title='세부직군' placeholder='세부직군' />
-          <WrappedInput title='관심 도메인' placeholder='관심도메인' />
-          <WrappedInput title='한 줄 소개' placeholder='본인을 잘 드러낼 수 있는 문장을 작성해 주세요.' />
+          <Controller
+            control={control}
+            name="name"
+            render={({ field }) => (
+              <>
+                <WrappedInput title='이름' placeholder='이름을 입력해주세요.' {...field} />
+                {errors.name && <ErrorMsg errorMsg={errors.name.message} />}
+              </>
+            )}
+          />
+          <Controller
+            control={control}
+            name="detail_career"
+            render={({ field }) => (
+              <>
+                <WrappedInput title='세부직군' placeholder='세부직군' {...field} />
+                {errors.detail_career && <ErrorMsg errorMsg={errors.detail_career.message} />}
+              </>
+            )}
+          />
+          <Controller
+            control={control}
+            name="domain"
+            render={({ field }) => (
+              <>
+                <WrappedTagInput title='관심 도메인' placeholder='관심 도메인' {...field} />
+                {/* <WrappedInput title='관심 도메인' placeholder='관심도메인' {...field} />
+                {errors.domain && <ErrorMsg errorMsg={errors.domain.message} />} */}
+              </>
+            )}
+          />
+          <Controller
+            control={control}
+            name="description"
+            render={({ field }) => (
+              <>
+                <WrappedInput title='한 줄 소개' placeholder='본인을 잘 드러낼 수 있는 문장을 작성해 주세요.' {...field} />
+                {errors.description && <ErrorMsg errorMsg={errors.description.message} />}
+              </>
+            )}
+          />
         </div>
       </section>
     </>

--- a/src/features/multi-step-form/ui/careerForm/index.tsx
+++ b/src/features/multi-step-form/ui/careerForm/index.tsx
@@ -1,28 +1,90 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { match } from 'ts-pattern';
+
+import { Button } from '@/shared/ui/button';
+
+import { TOTAL_STEPS } from '../../config';
+import { cardCreateSchema, CareerFormData } from '../../schema';
+
 import FirstStep from './firstStep';
 import ThirdStep from './thridStep';
-import TwoStep from './twoStep';
 
 type CareerFormViewProps = {
   currentStep: number;
+  onNextStep: () => void;
 }
 
-// 스텝에 따른 Fomr 컴포넌트를 렌더링하는 컴포넌트
-const StepFormView = ({ currentStep }: { currentStep: number }) => {
-  const stepComponents: Record<number, JSX.Element> = {
-    1: <FirstStep />,
-    2: <TwoStep />,
-    3: <ThirdStep />,
+type StepFormViewProps = {
+  currentStep: number;
+};
+
+const initialValues: CareerFormData = {
+  name: '',
+  detail_career: '',
+  domain: '',
+  description: '',
+}
+
+const stepValidationFields: Record<number, (keyof CareerFormData)[]> = {
+  1: ["name", "detail_career", "domain", "description"],
+  2: [],
+  3: [],
+  4: []
+}
+
+function CareerFormView({ currentStep, onNextStep }: CareerFormViewProps) {
+  const formMethod = useForm<CareerFormData>({
+    resolver: zodResolver(cardCreateSchema),
+    defaultValues: initialValues,
+    mode: "onBlur",
+  });
+
+  const { handleSubmit, trigger } = formMethod;
+
+  // 최종 제출 시 처리
+  const onSubmit: SubmitHandler<CareerFormData> = async (data) => {
+    console.log('최종 제출 데이터', data);
   };
 
-  return stepComponents[currentStep] || <></>;
-}
+  // 각 스텝에 해당하는 필드만 trigger로 검증 후 다음 단계로 이동
+  const handleNextStep = async () => {
+    const fieldsToValidate = stepValidationFields[currentStep];
+    if (!fieldsToValidate) return;
 
-function CareerFormView({ currentStep }: CareerFormViewProps) {
+    const valid = await trigger(fieldsToValidate);
+
+    if (valid) {
+      if (currentStep < 1) {
+        onNextStep();
+      } else {
+        // 마지막 단계인 경우 form 제출
+        handleSubmit(onSubmit)();
+      }
+    }
+  };
+
+
   return (
     <>
-      <StepFormView currentStep={currentStep} />
+      <FormProvider {...formMethod}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <StepFormView currentStep={currentStep} />
+        </form>
+        <Button
+          onClick={handleNextStep}>{
+            currentStep < TOTAL_STEPS ? '다음' : '제출'}
+        </Button>
+      </FormProvider>
     </>
   )
 }
+
+const StepFormView = ({ currentStep }: StepFormViewProps) => {
+  return match(currentStep)
+    .with(1, () => <FirstStep />)
+    .with(2, () => <ThirdStep />)
+    .otherwise(() => <></>);
+};
 
 export default CareerFormView;

--- a/src/features/multi-step-form/ui/careerForm/twoStep.tsx
+++ b/src/features/multi-step-form/ui/careerForm/twoStep.tsx
@@ -1,9 +1,0 @@
-function TwoStep() {
-  return (
-    <div>
-      <h2>Step 2</h2>
-    </div>
-  );
-}
-
-export default TwoStep;

--- a/src/features/multi-step-form/ui/index.tsx
+++ b/src/features/multi-step-form/ui/index.tsx
@@ -6,45 +6,45 @@ import useHistoryBack from '@/shared/hooks/useHistoryBack';
 import { cn } from '@/shared/lib/utils';
 import { spacingStyles } from '@/shared/spacing';
 import Appbar from '@/shared/ui/appbar';
-import { Button } from '@/shared/ui/button';
 import ProgressBar from '@/shared/ui/progressBar';
+
+import { MINIMUM_STEP, TOTAL_STEPS } from '../config';
 
 import CareerFormView from './careerForm';
 
 function MultiStepFormView() {
   const handleBack = useHistoryBack();
-  const [currentStep, setCurrentStep] = useState(1);
+  const [currentStep, setCurrentStep] = useState(MINIMUM_STEP);
 
   const handleNextStep = useCallback(() => {
     setCurrentStep((prev) => {
-      if (prev < 4) {
-        return prev + 1;
+      if (prev < TOTAL_STEPS) {
+        return prev + MINIMUM_STEP;
       }
       return prev;
     });
   }, [currentStep]);
 
-  const handleStepBack = () => {
+  const handleStepBack = useCallback(() => {
     setCurrentStep((prev) => {
-      if (prev > 1) {
-        return prev - 1;
+      if (prev > MINIMUM_STEP) {
+        return prev - MINIMUM_STEP;
       }
-      // 1단계인 경우 뒤로가기
-      if (prev === 1) {
+      // MINIMUM_STEP단계인 경우 뒤로가기
+      if (prev === MINIMUM_STEP) {
         handleBack();
       }
       return prev;
     });
-  }
+  }, [currentStep]);
 
   return (
     <div className="flex h-dvh w-full justify-center">
       <div className='flex flex-col w-full max-w-[600px] bg-gray-black'>
         <Appbar page='create' onLeftClick={handleStepBack} />
-        <ProgressBar currentStep={currentStep} totalSteps={4} />
+        <ProgressBar currentStep={currentStep} totalSteps={TOTAL_STEPS} />
         <main className={cn('flex flex-col gap-4', spacingStyles({ paddingX: 'ml', paddingY: 'lg' }))}>
-          <CareerFormView currentStep={currentStep} />
-          <Button onClick={handleNextStep}>등록</Button>
+          <CareerFormView currentStep={currentStep} onNextStep={handleNextStep} />
         </main>
       </div >
     </div>

--- a/src/shared/hooks/useDevice.ts
+++ b/src/shared/hooks/useDevice.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+
+type WindowSize = {
+  width?: number;
+  height?: number;
+};
+
+const MAX_MOBILE_SIZE = 992; // 모바일 최대 사이즈
+
+// 웹뷰 여부를 제공하는 hook
+const useWebview = () => {
+  const isWebViewRef = useRef(false);
+
+  useEffect(() => {
+    if (isWebViewRef.current) return;
+
+    if (typeof window !== 'undefined' && window.ReactNativeWebView) {
+      isWebViewRef.current = true;
+    }
+  }, []);
+
+  return {
+    isWebView: isWebViewRef.current,
+  };
+};
+
+// 윈도우 사이즈를 제공하는 hook
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      const { innerWidth: width, innerHeight: height } = window;
+      setWindowSize({ width, height });
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+};
+
+// 디바이스 정보를 제공하는 hook
+const useDevice = () => {
+  const { isWebView } = useWebview();
+  const { width: windowWidth } = useWindowSize();
+  const isMobile = !!windowWidth && windowWidth < MAX_MOBILE_SIZE;
+
+  return { isWebView, isMobile };
+};
+
+export default useDevice;

--- a/src/shared/ui/Input/index.tsx
+++ b/src/shared/ui/Input/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Image from 'next/image';
-import React, { useCallback, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 
 import { InputBody } from './input';
 
@@ -22,42 +22,52 @@ type WrappedInputPropsType = React.ComponentPropsWithoutRef<'input'> & {
  * @returns {JSX.Element} - WrappedInput 컴포넌트
  */
 
-function WrappedInput({ variant = 'default', title, ...props }: WrappedInputPropsType) {
-  const [value, setValue] = useState('');
+const WrappedInput = forwardRef<HTMLInputElement, WrappedInputPropsType>(
+  ({ variant = 'default', title, ...props }, ref) => {
+    const [value, setValue] = useState('');
 
-  const handleClearInput = useCallback(() => {
-    setValue('');
-  }, []);
+    const handleClearInput = useCallback(() => {
+      setValue('');
+    }, []);
 
-  const renderTitle = () => {
-    if (!title) return null;
-    if (variant === 'withBtn') {
-      return (
-        <div className="flex w-full justify-between">
-          <p className="text-body-5 text-gray-100">{title}</p>
-          <p className="text-caption-1 text-gray-200">추가</p>
-        </div>
-      );
-    }
-    return <p className="text-body-5 text-gray-100">{title}</p>;
-  };
+    const renderTitle = () => {
+      if (!title) return null;
+      if (variant === 'withBtn') {
+        return (
+          <div className="flex w-full justify-between">
+            <p className="text-body-5 text-gray-100">{title}</p>
+            <p className="text-caption-1 text-gray-200">추가</p>
+          </div>
+        );
+      }
+      return <p className="text-body-5 text-gray-100">{title}</p>;
+    };
 
-  return (
-    <div className="relative flex flex-col items-start justify-center gap-[6px]">
-      {renderTitle()}
-      <InputBody variant={variant} value={value} onChange={(e) => setValue(e.target.value)} {...props}></InputBody>
-      {variant === 'withBtn' && (
-        <Image
-          src="/icons/deleteIcon.svg"
-          alt="삭제 아이콘"
-          width={16}
-          height={16}
-          className={`absolute right-3 ${title && 'bottom-[14.5px]'} h-4 w-4 cursor-pointer`}
-          onClick={handleClearInput}
+    return (
+      <div className="relative flex flex-col items-start justify-center gap-[6px]">
+        {renderTitle()}
+        <InputBody
+          variant={variant}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          ref={ref}
+          {...props}
         />
-      )}{' '}
-    </div>
-  );
-}
+        {variant === 'withBtn' && (
+          <Image
+            src="/icons/deleteIcon.svg"
+            alt="삭제 아이콘"
+            width={16}
+            height={16}
+            className={`absolute right-3 ${title && 'bottom-[14.5px]'} h-4 w-4 cursor-pointer`}
+            onClick={handleClearInput}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+WrappedInput.displayName = 'WrappedInput';
 
 export default WrappedInput;


### PR DESCRIPTION
## 📌 개요

카드 생성 도메인의 폼 단계를 구현하였습니다.

### 기능

* ts patern을 사용하여 단계를 구분지었습니다.
* FormContext를 사용하여 각 단계의 상태를 공유하게 했습니다.
* 새로고침시 데이터를 공유하는 부분은 추후 zustand persist를 사용하여 관리할 예정입니다. (웹)
* 웹뷰인지, 모바일 디바이스인지 웹인지 체크하는 hooks을 구현하였습니다.
  * 추후 RN과 통신하는 용도입니다.

### 함수

## ✅ 체크사항

- [x] 기능이 정상적으로 동작하는지 확인
- [x] 코드 스타일 및 규칙 준수 확인
- [x] UI가 변경된 경우 스크린샷 첨부 여부 확인
