### PR TITLE
[feat] 명함 상세 페이지 API  연동

### DIFF
--- a/src/features/card-detail/hooks/query/useCardDetailQuery.ts
+++ b/src/features/card-detail/hooks/query/useCardDetailQuery.ts
@@ -1,8 +1,7 @@
 // api/cardQueries.ts
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
-import { MyCardDto } from '@/features/home/types';
 import { client } from '@/shared/apis/client';
 import { CLIENT_SIDE_URL } from '@/shared/constants';
 
@@ -12,64 +11,10 @@ import { CardDetailDto } from '../../types/cardDetail';
 
 export const CARD_DETAIL_QUERY_KEY = 'cardDetail';
 
-const getCardDetail = async (cardId: string, type: string): Promise<CardDetailDto> => {
-  const numCardId = Number(cardId);
-  // 각 cardId 값에 따라 다른 상태 코드의 에러 테스트
-  if (numCardId === 400) {
-    // AxiosError 형식에 맞춰 에러 객체 생성
-    const error = new Error('잘못된 요청 형식입니다.') as any;
-    error.isAxiosError = true;
-    error.response = {
-      status: 400,
-      data: { message: '잘못된 요청 형식입니다.' },
-    };
-    error.status = 400;
-    throw error;
-  }
-
-  if (numCardId === 401) {
-    const error = new Error('인증이 필요합니다.') as any;
-    error.isAxiosError = true;
-    error.response = {
-      status: 401,
-      data: { message: '로그인 세션이 만료되었습니다.' },
-    };
-    error.status = 401;
-    throw error;
-  }
-
-  if (numCardId === 403) {
-    const error = new Error('접근 권한이 없습니다.') as any;
-    error.isAxiosError = true;
-    error.response = {
-      status: 403,
-      data: { message: '해당 카드에 접근할 권한이 없습니다.' },
-    };
-    error.status = 403;
-    throw error;
-  }
-
-  if (numCardId === 500) {
-    const error = new Error('서버 내부 오류') as any;
-    error.isAxiosError = true;
-    error.response = {
-      status: 500,
-      data: { message: '서버에서 오류가 발생했습니다.' },
-    };
-    error.status = 500;
-    throw error;
-  }
-
+const getCardDetail = async (cardId: string): Promise<CardDetailDto> => {
   try {
-    let apiUrl = `${CLIENT_SIDE_URL}/api/card/detail?cardId=${cardId}`;
-
-    // 받은 명함인지 구분
-    if (type === 'receivedcard') {
-      apiUrl = `${CLIENT_SIDE_URL}/api/card/received/detail?cardId=${cardId}`;
-    }
-
-    console.log(apiUrl, type);
-    const data = await client.get<CardDetailDto>(apiUrl);
+    const baseUrl = `${CLIENT_SIDE_URL}/api/card`;
+    const data = await client.get<CardDetailDto>(`${baseUrl}/detail?cardId=${cardId}`);
     return data;
   } catch (err) {
     // Axios 에러 처리
@@ -79,29 +24,29 @@ const getCardDetail = async (cardId: string, type: string): Promise<CardDetailDt
     throw err;
   }
 };
-// 내 명함 목록 조회
-const getMyCard = async (): Promise<MyCardDto> => {
-  const data = await client.get<MyCardDto>(`${CLIENT_SIDE_URL}/api/card/my`);
-  return data;
+
+const updateReceiveCard = async (cardId: string, memo: string) => {
+  const response = await client.put<any, CardDetailDto>(`${CLIENT_SIDE_URL}/api/card/receive`, {
+    cardId,
+    memo,
+  });
+  return response.data;
 };
 
 // 카드 상세 정보를 가져오는 쿼리 훅
-export const useCardDetailQuery = (cardId: string, type: string) => {
+export const useCardDetailQuery = (cardId: string) => {
   return useQuery({
     queryKey: [CARD_DETAIL_QUERY_KEY, cardId],
-    queryFn: () => getCardDetail(cardId, type),
+    queryFn: () => getCardDetail(cardId),
 
     // 이후 Errorboundary를 사용하면 true 설정
     throwOnError: false,
   });
 };
 
-// 내 명함 목록 조회
-export const useMyCardQuery = () => {
-  const data = useQuery({
-    queryKey: ['myCard'],
-    queryFn: () => getMyCard(),
+// 카드 업데이트를 위한 mutation 훅
+export const useUpdateCardMutation = () => {
+  return useMutation({
+    mutationFn: ({ cardId, memo }: { cardId: string; memo: string }) => updateReceiveCard(cardId, memo),
   });
-
-  return data;
 };

--- a/src/features/card-detail/hooks/useScroll.ts
+++ b/src/features/card-detail/hooks/useScroll.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export const useScroll = () => {
+  const [isScroll, setIsScroll] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScroll(window.scrollY > 10);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return isScroll;
+};

--- a/src/features/card-detail/mocks/myCardDetail.ts
+++ b/src/features/card-detail/mocks/myCardDetail.ts
@@ -13,8 +13,17 @@ export const mockCardDetailData: CardDetailDto = {
     organization: '디프만',
     summary: '사용자 경험을 중요시하는 프론트엔드 개발자입니다. ',
     region: '게더',
-    group: ['디프만', '엘리스랩'],
-    introduce: '디프만 web 16기 윤장원입니다!',
+    folders: [
+      {
+        id: 1,
+        name: '디프만',
+      },
+      {
+        id: 2,
+        name: '엘리스랩',
+      },
+    ],
+    memo: '디프만 web 16기 윤장원입니다!',
     interestDomain: [],
     sns: [
       {

--- a/src/features/card-detail/types/cardDetail.ts
+++ b/src/features/card-detail/types/cardDetail.ts
@@ -28,6 +28,11 @@ export type ProjectDto = {
   description: string;
 };
 
+export type FolderDto = {
+  id: string;
+  name: string;
+};
+
 // 명함 상세 정보 타입
 export type CardDetailResponse = {
   nickname: string;
@@ -36,8 +41,8 @@ export type CardDetailResponse = {
   organization: string;
   summary: string;
   region: string;
-  group?: string[];
-  introduce?: string;
+  folders?: FolderDto[];
+  memo?: string;
   interestDomain?: string[] | undefined;
   sns?: SnsDto[] | undefined;
   news?: string | undefined;

--- a/src/features/card-detail/types/cardDetail.ts
+++ b/src/features/card-detail/types/cardDetail.ts
@@ -29,7 +29,7 @@ export type ProjectDto = {
 };
 
 export type FolderDto = {
-  id: string;
+  id: number;
   name: string;
 };
 

--- a/src/features/card-detail/ui/bottomSheet.tsx
+++ b/src/features/card-detail/ui/bottomSheet.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { BottomModal } from '@/shared/ui/bottomModal/bottomModal';
+import { BottomMenuItem } from '@/shared/ui/bottomModal/bottomModalItem';
+import BottomModalTitle from '@/shared/ui/bottomModal/bottomModalTitle';
+import { MemoInput } from '@/shared/ui/bottomModal/memoInput';
+
+type BottomSheetProps = {
+  mode: boolean;
+  isModalOpen: boolean;
+  closeModal: () => void;
+  handleMode: () => void;
+  handleCancelMode: () => void;
+};
+
+function BottomSheet({ mode, isModalOpen, closeModal, handleMode, handleCancelMode }: BottomSheetProps) {
+  return !mode ? (
+    <BottomModal isModalOpen={isModalOpen} closeModal={closeModal} mode={mode}>
+      <BottomMenuItem onClick={handleMode}>한줄 메모</BottomMenuItem>
+      <BottomMenuItem className="font-bold text-error-medium">삭제하기</BottomMenuItem>
+    </BottomModal>
+  ) : (
+    <BottomModal isModalOpen={isModalOpen} closeModal={handleCancelMode} mode={mode}>
+      <BottomModalTitle>한줄 메모</BottomModalTitle>
+      <MemoInput onClose={closeModal} handleCancelMode={handleCancelMode} />
+    </BottomModal>
+  );
+}
+
+export default BottomSheet;

--- a/src/features/card-detail/ui/cardContent.tsx
+++ b/src/features/card-detail/ui/cardContent.tsx
@@ -12,11 +12,11 @@ interface CardContentProps {
   type: string;
 }
 function CardContent({ cardId, type }: CardContentProps) {
-  const { data } = useCardDetailQuery(cardId, type);
+  const { data } = useCardDetailQuery(cardId);
 
   return (
     <>
-      <CardDetailHeader data={data as CardDetailDto} />
+      <CardDetailHeader data={data as CardDetailDto} type={type} />
       <CardTabs data={data as CardDetailDto} />
     </>
   );

--- a/src/features/card-detail/ui/cardDetailHeader.tsx
+++ b/src/features/card-detail/ui/cardDetailHeader.tsx
@@ -2,29 +2,30 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
-import { Toaster } from 'sonner';
 
 import useHistoryBack from '@/shared/hooks/useHistoryBack';
 import { spacingStyles } from '@/shared/spacing/spacing';
 import Appbar from '@/shared/ui/appbar';
-import { BottomModal } from '@/shared/ui/bottomModal/bottomModal';
-import { BottomMenuItem } from '@/shared/ui/bottomModal/bottomModalItem';
-import BottomModalTitle from '@/shared/ui/bottomModal/bottomModalTitle';
-import { MemoInput } from '@/shared/ui/bottomModal/memoInput';
 import Tag from '@/shared/ui/tag/tag';
+import Toast from '@/shared/ui/Toast';
 
 import JOB_CONFIG, { JobType } from '../config/jobs-config';
 import { useBottomModal } from '../hooks/useBottomModal';
+import { useScroll } from '../hooks/useScroll';
 import { CardDetailDto } from '../types/cardDetail';
+
+import BottomSheet from './bottomSheet';
 
 interface CardDetailHeaderProps {
   data: CardDetailDto;
+  type: string;
 }
 
-const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
+const CardDetailHeader = ({ data, type }: CardDetailHeaderProps) => {
   const { isModalOpen, headerRightHandler, closeModal } = useBottomModal();
   const [mode, setMode] = useState(false);
   const handleBack = useHistoryBack();
+  const isScroll = useScroll();
 
   const handleMode = () => {
     setMode(true);
@@ -34,8 +35,8 @@ const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
     setMode(false);
   };
 
-  // isMyCard : 받은 명함 임시적으로 명시
-  const isMyCard = false;
+  // isMyCard : 명함 타입 명시 (내 명함 , 받은 명함)
+  const isMyCard = type === 'mycard' ? true : false;
 
   const userJob = (data?.data?.job as JobType) || 'DEVELOPER';
 
@@ -51,7 +52,7 @@ const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
         }}
       >
         {/* 카드 상세 헤더 */}
-        <Appbar page="detail" onRightClick={headerRightHandler} onLeftClick={handleBack} />
+        <Appbar page="detail" onRightClick={headerRightHandler} onLeftClick={handleBack} isBlurred={isScroll} />
         {/* 카드 상세 userData */}
         <div className={`flex w-full items-start ${spacingStyles({ marginTop: 'ms' })}`}>
           <div
@@ -59,7 +60,7 @@ const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
           >
             <div className="flex w-full items-center justify-between">
               {/* 프로필 이미지 */}
-              {data?.data.nickname && (
+              {data?.data?.nickname && (
                 <div
                   className={`flex h-[56px] w-[56px] items-center justify-center rounded-full bg-gray-100 ${spacingStyles({ marginBottom: 'ms' })}`}
                 >
@@ -68,7 +69,7 @@ const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
               )}
 
               {/* 개발자 , 디자이너 아이콘 */}
-              {data?.data.job && <Image src={currentJob.iconPath} alt={currentJob.iconAlt} width="30" height="30" />}
+              {data?.data?.job && <Image src={currentJob.iconPath} alt={currentJob.iconAlt} width="30" height="30" />}
             </div>
             <p className="title-1 line-clamp-1">{data?.data.nickname}</p>
             <div
@@ -99,45 +100,39 @@ const CardDetailHeader = ({ data }: CardDetailHeaderProps) => {
                 <p className="line-clamp-1 text-body-5">{data?.data.region}</p>
               </div>
             )}
-
             {/* 이후 폴더를 map으로 수정 예정 */}
-            {!isMyCard && data?.data.group && (
+            {!isMyCard && data?.data.folders && (
               <div className={`${spacingStyles({ marginTop: 'lg' })} flex items-center`}>
-                {data?.data.group.map((e, i) => {
+                {data?.data.folders.map((e, i) => {
                   return (
                     <Tag
                       key={i}
-                      message={e}
+                      message={e.name}
                       className={`${spacingStyles({ marginRight: 'sm' })} bg-opacity-white-20`}
                     />
                   );
                 })}
               </div>
             )}
-
             {/* 한 줄 메모 */}
-            {!isMyCard && data?.data.introduce && (
+            {!isMyCard && data?.data.memo && (
               <div
                 className={`${spacingStyles({ paddingX: 'md', paddingY: 'ms', marginTop: 'md' })} w-full rounded-md bg-opacity-white-20`}
               >
-                <span className="line-clamp-2 text-body-5">{data?.data.introduce}</span>
+                <span className="line-clamp-2 text-body-5">{data?.data.memo}</span>
               </div>
             )}
           </div>
         </div>
       </div>
-      {!mode ? (
-        <BottomModal isModalOpen={isModalOpen} closeModal={closeModal} mode={mode}>
-          <BottomMenuItem onClick={handleMode}>한줄 메모</BottomMenuItem>
-          <BottomMenuItem className="text-error-medium">삭제하기</BottomMenuItem>
-        </BottomModal>
-      ) : (
-        <BottomModal isModalOpen={isModalOpen} closeModal={handleCancelMode} mode={mode}>
-          <BottomModalTitle>한줄 메모</BottomModalTitle>
-          <MemoInput onClose={closeModal} handleCancelMode={handleCancelMode} />
-        </BottomModal>
-      )}
-      <Toaster position="bottom-center" />
+      <BottomSheet
+        mode={mode}
+        isModalOpen={isModalOpen}
+        closeModal={closeModal}
+        handleMode={handleMode}
+        handleCancelMode={handleCancelMode}
+      />
+      <Toast />
     </>
   );
 };

--- a/src/features/card-detail/ui/cardTabs.tsx
+++ b/src/features/card-detail/ui/cardTabs.tsx
@@ -7,10 +7,6 @@ import useHistoryBack from '@/shared/hooks/useHistoryBack';
 import { cn } from '@/shared/lib/utils';
 import { spacingStyles } from '@/shared/spacing';
 import Appbar from '@/shared/ui/appbar';
-import { BottomModal } from '@/shared/ui/bottomModal/bottomModal';
-import { BottomMenuItem } from '@/shared/ui/bottomModal/bottomModalItem';
-import BottomModalTitle from '@/shared/ui/bottomModal/bottomModalTitle';
-import { MemoInput } from '@/shared/ui/bottomModal/memoInput';
 import { Typography } from '@/shared/ui/typography';
 
 import { CARD_TABS, TabId } from '../config/tabs-config';
@@ -19,6 +15,7 @@ import { useScrollPosition } from '../hooks/useScrollPosition';
 import useTabsActive from '../hooks/useTabsActive';
 import { CardDetailDto } from '../types/cardDetail';
 
+import BottomSheet from './bottomSheet';
 import DomainList from './domain';
 import Hobby from './hobby';
 import Posts from './posts';
@@ -216,17 +213,13 @@ function CardTabs({ data }: CardTabsProps) {
           )}
         </div>
       </div>
-      {!mode ? (
-        <BottomModal isModalOpen={isModalOpen} closeModal={closeModal} mode={mode}>
-          <BottomMenuItem onClick={handleMode}>한 줄 메모</BottomMenuItem>
-          <BottomMenuItem>삭제하기</BottomMenuItem>
-        </BottomModal>
-      ) : (
-        <BottomModal isModalOpen={isModalOpen} closeModal={handleCancelMode} mode={mode}>
-          <BottomModalTitle>한줄 메모</BottomModalTitle>
-          <MemoInput onClose={closeModal} handleCancelMode={handleCancelMode} />
-        </BottomModal>
-      )}
+      <BottomSheet
+        mode={mode}
+        isModalOpen={isModalOpen}
+        closeModal={closeModal}
+        handleMode={handleMode}
+        handleCancelMode={handleCancelMode}
+      />
     </>
   );
 }

--- a/src/shared/ui/appbar.tsx
+++ b/src/shared/ui/appbar.tsx
@@ -4,6 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import Image from 'next/image';
 import React from 'react';
 
+import { cn } from '../lib/utils';
+import { spacingStyles } from '../spacing';
+
 const appbarVariants = cva(
   'z-100 sticky top-0 flex h-16 min-h-16 w-full max-w-[600px] items-center justify-between px-4',
   {
@@ -40,9 +43,14 @@ type AppbarProps = AppbarVariantProps & {
   onRightClick?: () => void;
   onRightClickSecond?: () => void;
   title?: string;
+  isBlurred?: boolean;
 };
 
-function renderLeftIcon({ page, onLeftClick }: Pick<AppbarProps, 'page' | 'onLeftClick'>) {
+function renderLeftIcon({
+  page,
+  isBlurred = false,
+  onLeftClick,
+}: Pick<AppbarProps, 'page' | 'onLeftClick' | 'isBlurred'>) {
   switch (page) {
     case 'main':
       return (
@@ -51,6 +59,18 @@ function renderLeftIcon({ page, onLeftClick }: Pick<AppbarProps, 'page' | 'onLef
         </button>
       );
     case 'detail':
+      return (
+        <button
+          onClick={onLeftClick}
+          className={cn(
+            'rounded-full transition-colors duration-200',
+            isBlurred && 'bg-[rgba(255,255,255,0.10)]',
+            spacingStyles({ padding: 'sm' }),
+          )}
+        >
+          <Image src="/icons/leftArrow-white.svg" alt="이전 아이콘" width={24} height={24} />
+        </button>
+      );
     case 'create':
     case 'mypage':
       return (
@@ -73,7 +93,8 @@ function renderRightIcon({
   page,
   onRightClick,
   onRightClickSecond,
-}: Pick<AppbarProps, 'page' | 'onRightClick' | 'onRightClickSecond'>) {
+  isBlurred,
+}: Pick<AppbarProps, 'page' | 'onRightClick' | 'onRightClickSecond' | 'isBlurred'>) {
   switch (page) {
     case 'main':
       return (
@@ -83,7 +104,14 @@ function renderRightIcon({
       );
     case 'detail':
       return (
-        <button onClick={onRightClick}>
+        <button
+          onClick={onRightClick}
+          className={cn(
+            'rounded-full transition-colors duration-200',
+            isBlurred && 'bg-[rgba(255,255,255,0.10)]',
+            spacingStyles({ padding: 'sm' }),
+          )}
+        >
           <Image src="/icons/menuIcon-white.svg" alt="메뉴 아이콘" width={24} height={24} />
         </button>
       );
@@ -127,14 +155,16 @@ function renderRightIcon({
  * @returns {JSX.Element} - appbar 컴포넌트
  */
 
-function Appbar({ page, hasBackground, title, onLeftClick, onRightClick, onRightClickSecond }: AppbarProps) {
+function Appbar({ page, hasBackground, title, onLeftClick, onRightClick, onRightClickSecond, isBlurred }: AppbarProps) {
   return (
-    <header className={appbarVariants({ page, hasBackground })}>
-      <div className="flex flex-1">{renderLeftIcon({ page, onLeftClick })}</div>
+    <header className={cn(appbarVariants({ page, hasBackground }))}>
+      <div className="flex flex-1">{renderLeftIcon({ page, onLeftClick, isBlurred })}</div>
 
       {title && <h1 className="flex-1 text-center text-body-3 text-white">{title}</h1>}
 
-      <div className="flex flex-1 justify-end">{renderRightIcon({ page, onRightClick, onRightClickSecond })}</div>
+      <div className="flex flex-1 justify-end">
+        {renderRightIcon({ page, onRightClick, onRightClickSecond, isBlurred })}
+      </div>
     </header>
   );
 }

--- a/src/shared/ui/bottomModal/bottomModal.tsx
+++ b/src/shared/ui/bottomModal/bottomModal.tsx
@@ -77,7 +77,7 @@ export const BottomModal = ({ isModalOpen, closeModal, mode, children }: BottomM
             initial={{ opacity: 0 }}
             animate={{ opacity: 0.6 }}
             exit={{ opacity: 0 }}
-            className="z-modalBackground absolute inset-0 bg-black"
+            className="absolute inset-0 z-modalBackground bg-black"
             onClick={closeModal}
           />
 
@@ -96,14 +96,12 @@ export const BottomModal = ({ isModalOpen, closeModal, mode, children }: BottomM
             onDragEnd={handleDragEnd}
             style={{ y }}
             className={cn(
-              'z-bottomSheet fixed bottom-0 left-0 right-0 mx-auto max-w-[600px] rounded-t-2xl bg-gray-600',
+              'fixed bottom-0 left-0 right-0 z-bottomSheet mx-auto max-w-[600px] rounded-t-2xl bg-gray-600',
               mode ? 'z-bottomSheet' : 'z-bottomSheet',
             )}
           >
             <div className={`relative flex w-full flex-col ${spacingStyles({ paddingBottom: 'xl' })}`}>
-              <div
-                className={`h-[6px] w-[60px] self-center rounded-full bg-gray-800 ${spacingStyles({ marginTop: 'ms', marginBottom: 'ms' })}`}
-              />
+              <div className="mb-[12px] mt-[10px] h-[6px] w-[60px] self-center rounded-full bg-gray-800" />
 
               {children}
             </div>

--- a/src/shared/ui/bottomModal/bottomModalItem.tsx
+++ b/src/shared/ui/bottomModal/bottomModalItem.tsx
@@ -38,10 +38,10 @@ export const BottomMenuItem = ({
     >
       <p className={cn('body-3 text-white', className)}>{children}</p>
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center">
         {/* 수정 아이콘 */}
         {update !== undefined && (
-          <div onClick={(e) => handleIconClick(e, update)} className="cursor-pointer">
+          <div onClick={(e) => handleIconClick(e, update)} className="mr-[20px] cursor-pointer">
             <Image src="/icons/edit.svg" alt="수정" width={20} height={20} />
           </div>
         )}

--- a/src/shared/ui/bottomModal/bottomModalTitle.tsx
+++ b/src/shared/ui/bottomModal/bottomModalTitle.tsx
@@ -6,7 +6,7 @@ interface BottomModalTitleProps {
 
 function BottomModalTitle({ children }: BottomModalTitleProps) {
   return (
-    <div className="mb-4 w-full text-center">
+    <div className="mb-[28px] mt-[20px] w-full text-center">
       <div className="w-full text-body-2 font-bold text-white">{children}</div>
     </div>
   );


### PR DESCRIPTION
## 📌 개요
명함 상세 페이지 API  연동

## 📋 변경사항
- appbar 컴포넌트 -> isBlurred 추가
- bottom sheet -> 간격 수정

### 기능
- 내 명항 상세 , 받은 명함 상세  , 한줄 메모 기능 추가
### 화면

| 기능 | 스크린샷 |
| ---- | -------- |


## ✅ 체크사항

- [x] 기능이 정상적으로 동작하는지 확인
- [x] 코드 스타일 및 규칙 준수 확인
- [x] UI가 변경된 경우 스크린샷 첨부 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 카드 상세 정보 페이지에 카드 메모 업데이트가 가능해졌습니다.
  - 스크롤 위치에 따라 앱바가 블러 효과를 적용하며, 모달 인터페이스도 개선되어 메모 입력 및 삭제 작업을 지원합니다.

- **UI 개선**
  - 카드 상세 뷰가 폴더와 메모 기반으로 재구성되어 정보 구성이 명확해졌습니다.
  - 모달 및 아이콘 레이아웃 조정 등 인터페이스 전반에 걸쳐 사용자 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->