### PR TITLE
[feat] 명함 공유 로직 분리 및 토스트 위치 수정

### DIFF
--- a/src/app/(received)/received/page.tsx
+++ b/src/app/(received)/received/page.tsx
@@ -53,7 +53,7 @@ function Page() {
           </BottomMenuItem>
         </BottomModal>
         <Navbar />
-        <Toast bottomMargin="95px" />
+        <Toast bottomMargin="receive" />
       </div>
     </div>
   );

--- a/src/app/(received)/received/page.tsx
+++ b/src/app/(received)/received/page.tsx
@@ -53,7 +53,7 @@ function Page() {
           </BottomMenuItem>
         </BottomModal>
         <Navbar />
-        <Toast />
+        <Toast bottomMargin="95px" />
       </div>
     </div>
   );

--- a/src/features/card-detail/hooks/useScroll.ts
+++ b/src/features/card-detail/hooks/useScroll.ts
@@ -6,14 +6,25 @@ export const useScroll = () => {
   const [isScroll, setIsScroll] = useState(false);
 
   useEffect(() => {
+    // 스크롤 컨테이너 찾기
+    const scrollContainer = document.querySelector('.overflow-y-auto') || window;
+
     const handleScroll = () => {
-      setIsScroll(window.scrollY > 10);
+      if (scrollContainer === window) {
+        setIsScroll(window.scrollY > 10);
+      } else {
+        setIsScroll((scrollContainer as HTMLElement).scrollTop > 10);
+      }
     };
 
-    window.addEventListener('scroll', handleScroll);
+    // 이벤트 리스너 등록
+    scrollContainer.addEventListener('scroll', handleScroll);
+
+    // 초기 상태 확인
+    handleScroll();
 
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      scrollContainer.removeEventListener('scroll', handleScroll);
     };
   }, []);
 

--- a/src/features/card-detail/ui/cardDetail.tsx
+++ b/src/features/card-detail/ui/cardDetail.tsx
@@ -21,7 +21,7 @@ function CardDetail() {
     <div className="w-full overflow-y-auto scrollbar-hide">
       <CardDetailHeader data={data as CardDetailDto} type={type as string} />
       <CardTabs data={data as CardDetailDto} type={type as string} />
-      <Toast bottomMargin="20px" />
+      <Toast bottomMargin="detail" />
     </div>
   );
 }

--- a/src/features/card-detail/ui/cardDetail.tsx
+++ b/src/features/card-detail/ui/cardDetail.tsx
@@ -21,7 +21,7 @@ function CardDetail() {
     <div className="w-full overflow-y-auto scrollbar-hide">
       <CardDetailHeader data={data as CardDetailDto} type={type as string} />
       <CardTabs data={data as CardDetailDto} type={type as string} />
-      <Toast />
+      <Toast bottomMargin="20px" />
     </div>
   );
 }

--- a/src/features/home/containers/CardContainer.tsx
+++ b/src/features/home/containers/CardContainer.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-import SNS_CONFIG from '@/features/card-detail/config/sns-config';
-import { PreviewInfo } from '@/features/share/types';
+import { convertPreviewInfo } from '@/features/share/utils/convertPreviewType';
+import { getPreviewContentByType } from '@/features/share/utils/getPreviewContent';
 
 import { AddCard } from '../components/BusinessCard/AddCard';
 import {
@@ -19,7 +19,6 @@ import {
   WrappedCard,
 } from '../components/BusinessCard/Card';
 import { useCardQuery } from '../hooks/queries/useCardQuery';
-import { PreviewInfoType } from '../types';
 
 import { ClipboardContainer } from './ClipboardContainer';
 
@@ -36,58 +35,6 @@ export const CardContainer = () => {
   if (!data) return null;
 
   const { cards } = data;
-
-  const getPreviewContent = (previewInfoType: string, project: PreviewInfo) => {
-    switch (previewInfoType) {
-      case 'PROJECT':
-        return project.project
-          ? {
-              title: project.project.title,
-              description: project.project.description,
-              imageUrl: project.project.imageUrl,
-            }
-          : {};
-      case 'CONTENT':
-        return project.content
-          ? {
-              title: project.content?.title,
-              description: project.content?.description,
-              imageUrl: project.content?.imageUrl,
-            }
-          : {};
-      case 'SNS':
-        return project.sns
-          ? {
-              title: project.sns.type,
-              description: project.sns.link,
-              imageUrl: SNS_CONFIG[project.sns.type as keyof typeof SNS_CONFIG]?.iconPath || '/icons/imageIcon.svg',
-            }
-          : {};
-      case 'HOBBY':
-        return project.hobby
-          ? {
-              title: project.hobby,
-              description: '',
-            }
-          : {};
-      case 'NEWS':
-        return project.news
-          ? {
-              title: project.news,
-              description: '',
-            }
-          : {};
-      case 'REGION':
-        return project.region
-          ? {
-              title: project.region,
-              description: '',
-            }
-          : {};
-      default:
-        return {};
-    }
-  };
 
   return (
     <>
@@ -112,7 +59,7 @@ export const CardContainer = () => {
             previewInfo: project,
             previewInfoType,
           }) => {
-            const previewContent = getPreviewContent(previewInfoType, project);
+            const previewContent = getPreviewContentByType(project, previewInfoType);
             return (
               <SwiperSlide
                 key={id}
@@ -176,15 +123,4 @@ export const CardContainer = () => {
       )}
     </>
   );
-};
-
-const convertPreviewInfo = (previewInfo: PreviewInfoType) => {
-  return {
-    PROJECT: '대표 프로젝트',
-    CONTENT: '작성한 글',
-    HOBBY: '취미',
-    SNS: 'SNS',
-    NEWS: '최근 소식',
-    REGION: '활동 지역',
-  }[previewInfo];
 };

--- a/src/features/share/container/ShareCardContentContainer.tsx
+++ b/src/features/share/container/ShareCardContentContainer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import SNS_CONFIG from '@/features/card-detail/config/sns-config';
 import { Card, JopType, PreviewInfoType } from '@/features/home/types';
 
 import {
@@ -13,6 +12,8 @@ import {
   ShareCardFooter,
 } from '../components/ShareCard';
 import { PreviewInfo } from '../types';
+import { convertPreviewInfo } from '../utils/convertPreviewType';
+import { getPreviewContentByType } from '../utils/getPreviewContent';
 
 type ShareCardContentContainerProps = {
   cardData: Card;
@@ -25,55 +26,7 @@ export const ShareCardContentContainer = ({ cardData }: ShareCardContentContaine
     const previewInfo = cardData.previewInfo as PreviewInfo;
     const type = cardData.previewInfoType.toUpperCase();
 
-    switch (type) {
-      case 'PROJECT':
-        return previewInfo.project
-          ? {
-              title: previewInfo.project.title,
-              description: previewInfo.project.description,
-              imageUrl: previewInfo.project.imageUrl,
-            }
-          : {};
-      case 'CONTENT':
-        return previewInfo.content
-          ? {
-              title: previewInfo.content.title,
-              description: previewInfo.content.description,
-              imageUrl: previewInfo.content.imageUrl,
-            }
-          : {};
-      case 'SNS':
-        return previewInfo.sns
-          ? {
-              title: previewInfo.sns.type,
-              description: previewInfo.sns.link,
-              imageUrl: SNS_CONFIG[previewInfo.sns.type as keyof typeof SNS_CONFIG]?.iconPath || '/icons/imageIcon.svg',
-            }
-          : {};
-      case 'HOBBY':
-        return previewInfo.hobby
-          ? {
-              title: previewInfo.hobby,
-              description: '',
-            }
-          : {};
-      case 'NEWS':
-        return previewInfo.news
-          ? {
-              title: previewInfo.news,
-              description: '',
-            }
-          : {};
-      case 'REGION':
-        return previewInfo.region
-          ? {
-              title: previewInfo.region,
-              description: '',
-            }
-          : {};
-      default:
-        return {};
-    }
+    return getPreviewContentByType(previewInfo, type);
   };
 
   const previewContent = getPreviewContent();
@@ -96,15 +49,4 @@ export const ShareCardContentContainer = ({ cardData }: ShareCardContentContaine
       />
     </WrappedCard>
   );
-};
-
-const convertPreviewInfo = (previewInfo: PreviewInfoType) => {
-  return {
-    PROJECT: '대표 프로젝트',
-    CONTENT: '작성한 글',
-    HOBBY: '취미',
-    SNS: 'SNS',
-    NEWS: '최근 소식',
-    REGION: '활동 지역',
-  }[previewInfo];
 };

--- a/src/features/share/utils/convertPreviewType.ts
+++ b/src/features/share/utils/convertPreviewType.ts
@@ -1,0 +1,13 @@
+import { PreviewInfoType } from '../types';
+
+// 미리보기 정보 타입 변환 함수
+export const convertPreviewInfo = (previewInfo: PreviewInfoType) => {
+  return {
+    PROJECT: '대표 프로젝트',
+    CONTENT: '작성한 글',
+    HOBBY: '취미',
+    SNS: 'SNS',
+    NEWS: '최근 소식',
+    REGION: '활동 지역',
+  }[previewInfo];
+};

--- a/src/features/share/utils/getPreviewContent.ts
+++ b/src/features/share/utils/getPreviewContent.ts
@@ -1,0 +1,56 @@
+import SNS_CONFIG from '@/features/card-detail/config/sns-config';
+
+import { PreviewInfo } from '../types';
+
+// 미리보기 정보 변환을 처리하는 함수 분리
+export const getPreviewContentByType = (previewInfo: PreviewInfo, type: string) => {
+  switch (type) {
+    case 'PROJECT':
+      return previewInfo.project
+        ? {
+            title: previewInfo.project.title,
+            description: previewInfo.project.description,
+            imageUrl: previewInfo.project.imageUrl,
+          }
+        : {};
+    case 'CONTENT':
+      return previewInfo.content
+        ? {
+            title: previewInfo.content.title,
+            description: previewInfo.content.description,
+            imageUrl: previewInfo.content.imageUrl,
+          }
+        : {};
+    case 'SNS':
+      return previewInfo.sns
+        ? {
+            title: previewInfo.sns.type,
+            description: previewInfo.sns.link,
+            imageUrl: SNS_CONFIG[previewInfo.sns.type as keyof typeof SNS_CONFIG]?.iconPath || '/icons/imageIcon.svg',
+          }
+        : {};
+    case 'HOBBY':
+      return previewInfo.hobby
+        ? {
+            title: previewInfo.hobby,
+            description: '',
+          }
+        : {};
+    case 'NEWS':
+      return previewInfo.news
+        ? {
+            title: previewInfo.news,
+            description: '',
+          }
+        : {};
+    case 'REGION':
+      return previewInfo.region
+        ? {
+            title: previewInfo.region,
+            description: '',
+          }
+        : {};
+    default:
+      return {};
+  }
+};

--- a/src/shared/ui/Toast/index.ts
+++ b/src/shared/ui/Toast/index.ts
@@ -1,1 +1,1 @@
-export type MarginValue = '20px' | '95px';
+export type MarginValue = 'detail' | 'receive';

--- a/src/shared/ui/Toast/index.ts
+++ b/src/shared/ui/Toast/index.ts
@@ -1,0 +1,1 @@
+export type MarginValue = '20px' | '95px';

--- a/src/shared/ui/Toast/index.tsx
+++ b/src/shared/ui/Toast/index.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 
 import { Toaster } from './sonner';
 
+import { MarginValue } from '.';
+
 /**
  * 공통 컴포넌트 - sonner(toast)
  *
@@ -15,7 +17,12 @@ import { Toaster } from './sonner';
  * @returns {JSX.Element} - Toaster 컴포넌트
  *
  */
-function Toast() {
+
+type ToastProps = {
+  bottomMargin?: MarginValue;
+};
+
+function Toast({ bottomMargin = '20px' }: ToastProps) {
   return (
     <>
       <Toaster
@@ -40,6 +47,7 @@ function Toast() {
           ),
         }}
         position="bottom-center"
+        bottomMargin={bottomMargin}
       />
     </>
   );

--- a/src/shared/ui/Toast/index.tsx
+++ b/src/shared/ui/Toast/index.tsx
@@ -22,7 +22,7 @@ type ToastProps = {
   bottomMargin?: MarginValue;
 };
 
-function Toast({ bottomMargin = '20px' }: ToastProps) {
+function Toast({ bottomMargin = 'detail' }: ToastProps) {
   return (
     <>
       <Toaster

--- a/src/shared/ui/Toast/sonner.tsx
+++ b/src/shared/ui/Toast/sonner.tsx
@@ -3,19 +3,39 @@
 import { useTheme } from 'next-themes';
 import { Toaster as Sonner } from 'sonner';
 
-type ToasterProps = React.ComponentProps<typeof Sonner>;
+import { cn } from '@/shared/lib/utils';
 
-const Toaster = ({ ...props }: ToasterProps) => {
+import { MarginValue } from '.';
+
+type ToasterProps = React.ComponentProps<typeof Sonner> & {
+  bottomMargin?: MarginValue;
+};
+
+const Toaster = ({ bottomMargin = '20px', ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme();
+
+  // 미리 정의된 마진 클래스 맵
+  const marginClasses: Record<MarginValue, string> = {
+    '20px': 'mb-[20px]',
+    '95px': 'mb-[95px]',
+  };
+
+  // 기본 토스트 클래스
+  const baseToastClass = cn(
+    'group toast flex justify-center items-center max-w-fit',
+    'group-[.toaster]:bg-gray-600 group-[.toaster]:text-gray-white group-[.toaster]:text-body-4',
+    'group-[.toaster]:rounded-full group-[.toaster]:border-none',
+    'group-[.toaster]:fixed group-[.toaster]:left-1/2 group-[.toaster]:transform group-[.toaster]:-translate-x-1/2',
+    marginClasses[bottomMargin], // 미리 정의된 클래스 사용
+  );
 
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group"
+      className={cn('toaster group')}
       toastOptions={{
         classNames: {
-          toast:
-            'group toast flex justify-center items-center max-w-fit group-[.toaster]:bg-gray-600 group-[.toaster]:text-gray-white group-[.toaster]:text-body-4 group-[.toaster]:rounded-full group-[.toaster]:border-none group-[.toaster]:m-auto group-[.toaster]:mb-20',
+          toast: baseToastClass,
           description: 'group-[.toast]:text-gray-white',
         },
       }}

--- a/src/shared/ui/Toast/sonner.tsx
+++ b/src/shared/ui/Toast/sonner.tsx
@@ -11,13 +11,13 @@ type ToasterProps = React.ComponentProps<typeof Sonner> & {
   bottomMargin?: MarginValue;
 };
 
-const Toaster = ({ bottomMargin = '20px', ...props }: ToasterProps) => {
+const Toaster = ({ bottomMargin = 'detail', ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme();
 
   // 미리 정의된 마진 클래스 맵
   const marginClasses: Record<MarginValue, string> = {
-    '20px': 'mb-[20px]',
-    '95px': 'mb-[95px]',
+    detail: 'mb-[20px]',
+    receive: 'mb-[95px]',
   };
 
   // 기본 토스트 클래스

--- a/src/shared/ui/appbar.tsx
+++ b/src/shared/ui/appbar.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { cn } from '../lib/utils';
 
 const appbarVariants = cva(
-  'z-100 sticky top-0 flex h-16 min-h-16 w-full max-w-[600px] items-center justify-between px-4',
+  'sticky z-bar top-0 flex h-16 min-h-16 w-full max-w-[600px] items-center justify-between px-4',
   {
     variants: {
       page: {


### PR DESCRIPTION
## 📌 개요
명함 공유 로직 분리 및 토스트 위치 수정

## 📋 변경사항
- 명함 공유 페이지 , 홈 페이지 썸네일 데이터 로직 분리
- 토스트 위치 수정
- 명함 상세 appbar blur 오류 수정

### 화면

| 기능 | 스크린샷 |
| ---- | -------- |
| 받은 명함 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/6a4c4470-7632-4d60-a61d-e85080ea3a54" />|
| 명함 상세 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/e5ddd4e4-8a6f-4c1d-9b87-f55659a5e7ab" />|


## ✅ 체크사항

- [x] 기능이 정상적으로 동작하는지 확인
- [x] 코드 스타일 및 규칙 준수 확인
- [x] UI가 변경된 경우 스크린샷 첨부 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Toast 알림에 이제 맞춤형 하단 여백 옵션이 추가되어, 페이지별 알림 위치가 보다 최적화되었습니다.
	- 스크롤 이벤트 감지 기능이 개선되어 원활한 사용자 인터랙션을 제공합니다.
  
- **Refactor**
	- 미리보기 콘텐츠 생성 로직이 통합되어, 콘텐츠 표시의 일관성이 향상되었습니다.
	- 앱바의 레이어 순위 조정으로 UI 요소의 안정성이 개선되었습니다.
	- 메모 입력 필드와 제출 버튼의 비활성화 기능이 추가되어, 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->